### PR TITLE
Fix - Sonar diff check should account for modified lines only

### DIFF
--- a/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
@@ -59,6 +59,14 @@ import org.sonar.api.PropertyType;
     description = "Issues will not be reported as inline comments but only in the global summary comment",
     project = true,
     global = true,
+    type = PropertyType.BOOLEAN),
+  @Property(
+    key = GitHubPlugin.GITHUB_PROCESS_ONLY_MODIFIED_LINES,
+    defaultValue = "false",
+    name = "Process only modified lines of code",
+    description = "",
+    project = true,
+    global = true,
     type = PropertyType.BOOLEAN)
 })
 public class GitHubPlugin implements Plugin {
@@ -68,6 +76,7 @@ public class GitHubPlugin implements Plugin {
   public static final String GITHUB_REPO = "sonar.github.repository";
   public static final String GITHUB_PULL_REQUEST = "sonar.github.pullRequest";
   public static final String GITHUB_DISABLE_INLINE_COMMENTS = "sonar.github.disableInlineComments";
+  public static final String GITHUB_PROCESS_ONLY_MODIFIED_LINES = "sonar.github.proccessOnlyModifiedLines";
 
   @Override
   public void define(Context context) {

--- a/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
@@ -64,7 +64,7 @@ import org.sonar.api.PropertyType;
     key = GitHubPlugin.GITHUB_PROCESS_ONLY_MODIFIED_LINES,
     defaultValue = "false",
     name = "Process only modified lines of code",
-    description = "",
+    description = "If this property set to true, then only modified lines of code would be analyzed by sonar",
     project = true,
     global = true,
     type = PropertyType.BOOLEAN)

--- a/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
@@ -61,10 +61,10 @@ import org.sonar.api.PropertyType;
     global = true,
     type = PropertyType.BOOLEAN),
   @Property(
-    key = GitHubPlugin.GITHUB_PROCESS_ONLY_MODIFIED_LINES,
+    key = GitHubPlugin.GITHUB_INLINE_COMMENTS_ONLY_ADDED_LINES,
     defaultValue = "false",
-    name = "Process only modified lines of code",
-    description = "If this property set to true, then only modified lines of code would be analyzed by sonar",
+    name = "Inline comments only about added lines",
+    description = "If this property set to true, then inline comments can be only about added or modified lines of code.",
     project = true,
     global = true,
     type = PropertyType.BOOLEAN)
@@ -76,7 +76,7 @@ public class GitHubPlugin implements Plugin {
   public static final String GITHUB_REPO = "sonar.github.repository";
   public static final String GITHUB_PULL_REQUEST = "sonar.github.pullRequest";
   public static final String GITHUB_DISABLE_INLINE_COMMENTS = "sonar.github.disableInlineComments";
-  public static final String GITHUB_PROCESS_ONLY_MODIFIED_LINES = "sonar.github.proccessOnlyModifiedLines";
+  public static final String GITHUB_INLINE_COMMENTS_ONLY_ADDED_LINES = "sonar.github.inlineCommentsOnlyAddedLines";
 
   @Override
   public void define(Context context) {

--- a/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPlugin.java
@@ -61,10 +61,10 @@ import org.sonar.api.PropertyType;
     global = true,
     type = PropertyType.BOOLEAN),
   @Property(
-    key = GitHubPlugin.GITHUB_INLINE_COMMENTS_ONLY_ADDED_LINES,
+    key = GitHubPlugin.GITHUB_INLINE_COMMENTS_DIFF_ONLY,
     defaultValue = "false",
-    name = "Inline comments only about added lines",
-    description = "If this property set to true, then inline comments can be only about added or modified lines of code.",
+    name = "Inline comment will be limited strictly to lines that are part of the diff",
+    description = "If this property set to true, then inline comment will be limited strictly to lines that are part of the diff.",
     project = true,
     global = true,
     type = PropertyType.BOOLEAN)
@@ -76,7 +76,7 @@ public class GitHubPlugin implements Plugin {
   public static final String GITHUB_REPO = "sonar.github.repository";
   public static final String GITHUB_PULL_REQUEST = "sonar.github.pullRequest";
   public static final String GITHUB_DISABLE_INLINE_COMMENTS = "sonar.github.disableInlineComments";
-  public static final String GITHUB_INLINE_COMMENTS_ONLY_ADDED_LINES = "sonar.github.inlineCommentsOnlyAddedLines";
+  public static final String GITHUB_INLINE_COMMENTS_DIFF_ONLY = "sonar.github.inlineCommentsDiffOnly";
 
   @Override
   public void define(Context context) {

--- a/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
@@ -116,5 +116,9 @@ public class GitHubPluginConfiguration {
   public boolean tryReportIssuesInline() {
     return !settings.getBoolean(GitHubPlugin.GITHUB_DISABLE_INLINE_COMMENTS);
   }
+  
+  public boolean processOnlyModifiedLines() {
+    return settings.getBoolean(GitHubPlugin.GITHUB_PROCESS_ONLY_MODIFIED_LINES);
+  }
 
 }

--- a/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
@@ -118,7 +118,7 @@ public class GitHubPluginConfiguration {
   }
   
   public boolean processOnlyModifiedLines() {
-    return settings.getBoolean(GitHubPlugin.GITHUB_INLINE_COMMENTS_ONLY_ADDED_LINES);
+    return settings.getBoolean(GitHubPlugin.GITHUB_INLINE_COMMENTS_DIFF_ONLY);
   }
 
 }

--- a/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
+++ b/src/main/java/org/sonar/plugins/github/GitHubPluginConfiguration.java
@@ -118,7 +118,7 @@ public class GitHubPluginConfiguration {
   }
   
   public boolean processOnlyModifiedLines() {
-    return settings.getBoolean(GitHubPlugin.GITHUB_PROCESS_ONLY_MODIFIED_LINES);
+    return settings.getBoolean(GitHubPlugin.GITHUB_INLINE_COMMENTS_ONLY_ADDED_LINES);
   }
 
 }

--- a/src/main/java/org/sonar/plugins/github/PullRequestFacade.java
+++ b/src/main/java/org/sonar/plugins/github/PullRequestFacade.java
@@ -155,13 +155,13 @@ public class PullRequestFacade {
         if (patch == null) {
           continue;
         }
-        processPatch(patchLocationMapping, patch);
+        processPatch(patchLocationMapping, patch, !config.processOnlyModifiedLines());
       }
     }
     return result;
   }
 
-  static void processPatch(Map<Integer, Integer> patchLocationMapping, String patch) throws IOException {
+  static void processPatch(Map<Integer, Integer> patchLocationMapping, String patch, boolean processAllLines) throws IOException {
     int currentLine = -1;
     int patchLocation = 0;
     BufferedReader reader = new BufferedReader(new StringReader(patch));
@@ -176,9 +176,12 @@ public class PullRequestFacade {
         currentLine = Integer.parseInt(matcher.group(1));
       } else if (line.startsWith("-")) {
         // Skip removed lines
-      } else if (line.startsWith("+") || line.startsWith(" ")) {
-        // Count added and unmodified lines
+      } else if (line.startsWith("+") || (processAllLines && line.startsWith(" "))) {
+        // Count added and unmodified lines if processAllLines==true
         patchLocationMapping.put(currentLine, patchLocation);
+        currentLine++;
+      } else if (!processAllLines && line.startsWith(" ")) {
+        // Keep current line up to date if processAllLines==false
         currentLine++;
       } else if (line.startsWith("\\")) {
         // I'm only aware of \ No newline at end of file

--- a/src/test/java/org/sonar/plugins/github/PullRequestFacadeTest.java
+++ b/src/test/java/org/sonar/plugins/github/PullRequestFacadeTest.java
@@ -74,7 +74,8 @@ public class PullRequestFacadeTest {
     PullRequestFacade
       .processPatch(
         patchLocationMapping,
-        "@@ -17,9 +17,6 @@\n  * along with this program; if not, write to the Free Software Foundation,\n  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.\n  */\n-/**\n- * Deprecated in 4.5.1. JFreechart charts are replaced by Javascript charts.\n- */\n @ParametersAreNonnullByDefault\n package org.sonar.plugins.core.charts;\n ");
+        "@@ -17,9 +17,6 @@\n  * along with this program; if not, write to the Free Software Foundation,\n  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.\n  */\n-/**\n- * Deprecated in 4.5.1. JFreechart charts are replaced by Javascript charts.\n- */\n @ParametersAreNonnullByDefault\n package org.sonar.plugins.core.charts;\n ",
+        true);
 
     assertThat(patchLocationMapping).containsOnly(MapEntry.entry(17, 1), MapEntry.entry(18, 2), MapEntry.entry(19, 3), MapEntry.entry(20, 7), MapEntry.entry(21, 8),
       MapEntry.entry(22, 9));
@@ -86,7 +87,8 @@ public class PullRequestFacadeTest {
     PullRequestFacade
       .processPatch(
         patchLocationMapping,
-        "@@ -24,9 +24,9 @@\n /**\n  * A plugin is a group of extensions. See <code>org.sonar.api.Extension</code> interface to browse\n  * available extension points.\n- * <p/>\n  * <p>The manifest property <code>Plugin-Class</code> must declare the name of the implementation class.\n  * It is automatically set by sonar-packaging-maven-plugin when building plugins.</p>\n+ * <p>Implementation must declare a public constructor with no-parameters.</p>\n  *\n  * @see org.sonar.api.Extension\n  * @since 1.10");
+        "@@ -24,9 +24,9 @@\n /**\n  * A plugin is a group of extensions. See <code>org.sonar.api.Extension</code> interface to browse\n  * available extension points.\n- * <p/>\n  * <p>The manifest property <code>Plugin-Class</code> must declare the name of the implementation class.\n  * It is automatically set by sonar-packaging-maven-plugin when building plugins.</p>\n+ * <p>Implementation must declare a public constructor with no-parameters.</p>\n  *\n  * @see org.sonar.api.Extension\n  * @since 1.10",
+        true);
 
     assertThat(patchLocationMapping).containsOnly(MapEntry.entry(24, 1), MapEntry.entry(25, 2), MapEntry.entry(26, 3), MapEntry.entry(27, 5), MapEntry.entry(28, 6),
       MapEntry.entry(29, 7), MapEntry.entry(30, 8), MapEntry.entry(31, 9), MapEntry.entry(32, 10));
@@ -98,7 +100,8 @@ public class PullRequestFacadeTest {
     PullRequestFacade
       .processPatch(
         patchLocationMapping,
-        "@@ -1 +0,0 @@\n-<fake/>\n\\ No newline at end of file");
+        "@@ -1 +0,0 @@\n-<fake/>\n\\ No newline at end of file",
+        true);
 
     assertThat(patchLocationMapping).isEmpty();
   }

--- a/src/test/java/org/sonar/plugins/github/PullRequestFacadeTest.java
+++ b/src/test/java/org/sonar/plugins/github/PullRequestFacadeTest.java
@@ -93,6 +93,18 @@ public class PullRequestFacadeTest {
     assertThat(patchLocationMapping).containsOnly(MapEntry.entry(24, 1), MapEntry.entry(25, 2), MapEntry.entry(26, 3), MapEntry.entry(27, 5), MapEntry.entry(28, 6),
       MapEntry.entry(29, 7), MapEntry.entry(30, 8), MapEntry.entry(31, 9), MapEntry.entry(32, 10));
   }
+  
+  @Test
+  public void testPatchLineMapping_only_added_lines() throws IOException {
+    Map<Integer, Integer> patchLocationMapping = new LinkedHashMap<Integer, Integer>();
+    PullRequestFacade
+      .processPatch(
+        patchLocationMapping,
+        "@@ -24,9 +24,9 @@\n /**\n  * A plugin is a group of extensions. See <code>org.sonar.api.Extension</code> interface to browse\n  * available extension points.\n- * <p/>\n  * <p>The manifest property <code>Plugin-Class</code> must declare the name of the implementation class.\n  * It is automatically set by sonar-packaging-maven-plugin when building plugins.</p>\n+ * <p>Implementation must declare a public constructor with no-parameters.</p>\n  *\n  * @see org.sonar.api.Extension\n  * @since 1.10",
+        false);
+
+    assertThat(patchLocationMapping).containsOnly(MapEntry.entry(29, 7));
+  }
 
   @Test
   public void testPatchLineMapping_no_newline_at_the_end() throws IOException {


### PR DESCRIPTION
Added new property sonar.github.inlineCommentsOnlyAddedLines.  If it set to true inline comments can be only about added or modified lines of code. Currently it also takes few lines up and down from changes and it leads to situation when not modified lines have comments from sonar. 